### PR TITLE
Move IBot to API

### DIFF
--- a/ScreepsDotNet.API/API/Bot/IBot.cs
+++ b/ScreepsDotNet.API/API/Bot/IBot.cs
@@ -1,0 +1,13 @@
+namespace ScreepsDotNet.API.Bot
+{
+    /// <summary>
+    /// Represents a bot that can be run in the Screeps game.
+    /// </summary>
+    public interface IBot
+    {
+        /// <summary>
+        /// Called once per tick to perform the bot's logic.
+        /// </summary>
+        void Loop();
+    }
+}

--- a/ScreepsDotNet.ExampleArenaBot/Program.cs
+++ b/ScreepsDotNet.ExampleArenaBot/Program.cs
@@ -3,15 +3,10 @@ using System.Diagnostics.CodeAnalysis;
 
 namespace ScreepsDotNet
 {
-    public interface IBot
-    {
-        void Loop();
-    }
-
     public static partial class Program
     {
         private static API.Arena.IGame? game;
-        private static IBot? bot;
+        private static API.Bot.IBot? bot;
 
         [DynamicDependency(DynamicallyAccessedMemberTypes.PublicMethods, typeof(Program))]
         public static void Main()
@@ -19,7 +14,7 @@ namespace ScreepsDotNet
 
         }
 
-        private static IBot CreateBot(API.Arena.IGame game)
+        private static API.Bot.IBot CreateBot(API.Arena.IGame game)
             // Change this to switch the bot to a different tutorial!
             => new ExampleArenaBot.Tutorial10_FinalTest(game);
 

--- a/ScreepsDotNet.ExampleArenaBot/Tutorial10_FinalTest.cs
+++ b/ScreepsDotNet.ExampleArenaBot/Tutorial10_FinalTest.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 
 using ScreepsDotNet.API.Arena;
+using ScreepsDotNet.API.Bot;
 
 namespace ScreepsDotNet.ExampleArenaBot
 {

--- a/ScreepsDotNet.ExampleArenaBot/Tutorial1_ImportAndLoop.cs
+++ b/ScreepsDotNet.ExampleArenaBot/Tutorial1_ImportAndLoop.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 
 using ScreepsDotNet.API.Arena;
+using ScreepsDotNet.API.Bot;
 
 namespace ScreepsDotNet.ExampleArenaBot
 {

--- a/ScreepsDotNet.ExampleArenaBot/Tutorial3_FirstAttack.cs
+++ b/ScreepsDotNet.ExampleArenaBot/Tutorial3_FirstAttack.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 
 using ScreepsDotNet.API.Arena;
+using ScreepsDotNet.API.Bot;
 
 namespace ScreepsDotNet.ExampleArenaBot
 {

--- a/ScreepsDotNet.ExampleArenaBot/Tutorial4_CreepsBodies.cs
+++ b/ScreepsDotNet.ExampleArenaBot/Tutorial4_CreepsBodies.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 
 using ScreepsDotNet.API.Arena;
+using ScreepsDotNet.API.Bot;
 
 namespace ScreepsDotNet.ExampleArenaBot
 {

--- a/ScreepsDotNet.ExampleArenaBot/Tutorial5_StoreAndTransfer.cs
+++ b/ScreepsDotNet.ExampleArenaBot/Tutorial5_StoreAndTransfer.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 
 using ScreepsDotNet.API.Arena;
+using ScreepsDotNet.API.Bot;
 
 namespace ScreepsDotNet.ExampleArenaBot
 {

--- a/ScreepsDotNet.ExampleArenaBot/Tutorial7_SpawnCreeps.cs
+++ b/ScreepsDotNet.ExampleArenaBot/Tutorial7_SpawnCreeps.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using System.Collections.Generic;
 
 using ScreepsDotNet.API.Arena;
+using ScreepsDotNet.API.Bot;
 
 namespace ScreepsDotNet.ExampleArenaBot
 {

--- a/ScreepsDotNet.ExampleArenaBot/Tutorial8_HarvestEnergy.cs
+++ b/ScreepsDotNet.ExampleArenaBot/Tutorial8_HarvestEnergy.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 
 using ScreepsDotNet.API.Arena;
+using ScreepsDotNet.API.Bot;
 
 namespace ScreepsDotNet.ExampleArenaBot
 {

--- a/ScreepsDotNet.ExampleArenaBot/Tutorial9_Construction.cs
+++ b/ScreepsDotNet.ExampleArenaBot/Tutorial9_Construction.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 
 using ScreepsDotNet.API.Arena;
+using ScreepsDotNet.API.Bot;
 
 namespace ScreepsDotNet.ExampleArenaBot
 {

--- a/ScreepsDotNet.ExampleWorldBot/BasicExample.cs
+++ b/ScreepsDotNet.ExampleWorldBot/BasicExample.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 
 using ScreepsDotNet.API;
+using ScreepsDotNet.API.Bot;
 using ScreepsDotNet.API.World;
 
 namespace ScreepsDotNet.ExampleWorldBot
@@ -45,7 +46,7 @@ namespace ScreepsDotNet.ExampleWorldBot
                 }
                 roomManager.Tick();
             }
-            
+
         }
 
         private void CleanMemory()

--- a/ScreepsDotNet.ExampleWorldBot/Program.cs
+++ b/ScreepsDotNet.ExampleWorldBot/Program.cs
@@ -3,15 +3,10 @@ using System.Diagnostics.CodeAnalysis;
 
 namespace ScreepsDotNet
 {
-    public interface IBot
-    {
-        void Loop();
-    }
-
     public static partial class Program
     {
         private static API.World.IGame? game;
-        private static IBot? bot;
+        private static API.Bot.IBot? bot;
 
         [DynamicDependency(DynamicallyAccessedMemberTypes.PublicMethods, typeof(Program))]
         public static void Main()


### PR DESCRIPTION
By moving the two instances of IBot interface to the API, we create a common reference type for dealing with C# bots. Not a useful change in the simple C# to wasm to Screeps bot pipeline, but useful when wanting to use ScreepsDotNet bots outside of the wasm blob, such as with tests or using with custom `IGame` instance in a console application for testing.