### PR TITLE
Visual API fixes and optimisations

### DIFF
--- a/ScreepsDotNet.API/API/Visual.cs
+++ b/ScreepsDotNet.API/API/Visual.cs
@@ -2,25 +2,26 @@
 
 namespace ScreepsDotNet.API
 {
-    public readonly struct Color
+    public readonly struct Color(byte a, byte r, byte g, byte b)
     {
-        private readonly int value;
+        private readonly uint value = (uint)(a << 24) | (uint)(r << 16) | (uint)(g << 8) | b;
 
-        public byte R => (byte)(value >> 16 & 0xff);
-        public byte G => (byte)(value >> 8 & 0xff);
-        public byte B => (byte)(value >> 0 & 0xff);
+        public byte A => (byte)((value >> 24) & 0xff);
+        public byte R => (byte)((value >> 16) & 0xff);
+        public byte G => (byte)((value >> 8) & 0xff);
+        public byte B => (byte)((value >> 0) & 0xff);
 
+        public double ANorm => A / 255.0;
         public double RNorm => R / 255.0;
         public double GNorm => G / 255.0;
         public double BNorm => B / 255.0;
 
         public Color(byte r, byte g, byte b)
-        {
-            value = r << 16 | g << 8 | b;
-        }
+            : this(255, r, g, b)
+        { }
 
         public override string ToString()
-            => $"#{value.ToString("X").PadLeft(6, '0')}";
+            => a switch { 0 => "transparent", 255 => $"#{(value & 0xffffff).ToString("X").PadLeft(6, '0')}", _ => $"#{(value & 0xffffff).ToString("X").PadLeft(6, '0')}{A.ToString("X").PadLeft(2, '0')}" };
 
         public static Color FromNorm(double rNorm, double gNorm, double bNorm)
             => new((byte)(Math.Clamp(rNorm, 0.0, 1.0) * 255), (byte)(Math.Clamp(gNorm, 0.0, 1.0) * 255), (byte)(Math.Clamp(bNorm, 0.0, 1.0) * 255));
@@ -45,6 +46,8 @@ namespace ScreepsDotNet.API
         public static readonly Color LightBlue = new(128, 128, 255);
         public static readonly Color DarkBlue = new(0, 0, 128);
 
+        public static readonly Color Transparent = new(0, 255, 255, 255);
+
         #endregion
     }
 
@@ -61,250 +64,87 @@ namespace ScreepsDotNet.API
         Right
     }
 
-    public readonly struct CircleVisualStyle
-    {
-        /// <summary>
-        /// Circle radius, default is 0.15
-        /// </summary>
-        public readonly double Radius;
+    /// <param name="Radius">Circle radius, default is 0.15</param>
+    /// <param name="Fill">Fill color, default is white</param>
+    /// <param name="Opacity">Opacity value, default is 0.5</param>
+    /// <param name="Stroke">Stroke color, default is white</param>
+    /// <param name="StrokeWidth">Stroke line width, default is 0.1</param>
+    /// <param name="LineStyle">Either null (solid line), dashed, or dotted, default is solid</param>
+    public readonly record struct CircleVisualStyle
+    (
+        double? Radius = null,
+        Color? Fill = null,
+        double? Opacity = null,
+        Color? Stroke = null,
+        double? StrokeWidth = null,
+        LineStyle? LineStyle = null
+    );
 
-        /// <summary>
-        /// Fill color. Default is #ffffff
-        /// </summary>
-        public readonly Color Fill;
+    /// <param name="Width">Line width, default is 0.1</param>
+    /// <param name="Color">Line color, default is white</param>
+    /// <param name="Opacity">Opacity value, default is 0.5</param>
+    /// <param name="LineStyle">Either null (solid line), dashed, or dotted, default is solid</param>
+    public readonly record struct LineVisualStyle
+    (
+        double? Width = null,
+        Color? Color = null,
+        double? Opacity = null,
+        LineStyle? LineStyle = null
+    );
 
-        /// <summary>
-        /// Opacity value, default is 0.5
-        /// </summary>
-        public readonly double Opacity;
+    /// <param name="Fill">Fill color, default is white</param>
+    /// <param name="Opacity">Opacity value, default is 0.5</param>
+    /// <param name="Stroke">Stroke color, default is white</param>
+    /// <param name="StrokeWidth">Stroke line width, default is 0.1</param>
+    /// <param name="LineStyle">Either null (solid line), dashed, or dotted, default is solid</param>
+    public readonly record struct PolyVisualStyle
+    (
+        Color? Fill = null,
+        double? Opacity = null,
+        Color? Stroke = null,
+        double? StrokeWidth = null,
+        LineStyle? LineStyle = null
+    );
 
-        /// <summary>
-        /// Stroke color. Default is #ffffff
-        /// </summary>
-        public readonly Color Stroke;
+    /// <param name="Fill">Fill color, default is white</param>
+    /// <param name="Opacity">Opacity value, default is 0.5</param>
+    /// <param name="Stroke">Stroke color, default is white</param>
+    /// <param name="StrokeWidth">Stroke line width, default is 0.1</param>
+    /// <param name="LineStyle">Either null (solid line), dashed, or dotted, default is solid</param>
+    public readonly record struct RectVisualStyle
+    (
+        Color? Fill = null,
+        double? Opacity = null,
+        Color? Stroke = null,
+        double? StrokeWidth = null,
+        LineStyle? LineStyle = null
+    );
 
-        /// <summary>
-        /// Stroke line width, default is 0.1
-        /// </summary>
-        public readonly double StrokeWidth;
-
-        /// <summary>
-        /// Either undefined (solid line), dashed, or dotted. Default is undefined
-        /// </summary>
-        public readonly LineStyle? LineStyle;
-
-        public CircleVisualStyle(
-            double radius = 0.15,
-            Color? fill = null,
-            double opacity = 0.5,
-            Color? stroke = null,
-            double strokeWidth = 0.1,
-            LineStyle? lineStyle = null
-        )
-        {
-            Radius = radius;
-            Fill = fill ?? Color.White;
-            Opacity = opacity;
-            Stroke = stroke ?? Color.White;
-            StrokeWidth = strokeWidth;
-            LineStyle = lineStyle;
-        }
-
-        public CircleVisualStyle WithRadius(double newRadius)
-            => new(newRadius, Fill, Opacity, Stroke, StrokeWidth, LineStyle);
-    }
-
-    public readonly struct LineVisualStyle
-    {
-        /// <summary>
-        /// Line width, default is 0.1
-        /// </summary>
-        public readonly double Width;
-
-        /// <summary>
-        /// Line color. Default is #ffffff
-        /// </summary>
-        public readonly Color Color;
-
-        /// <summary>
-        /// Opacity value, default is 0.5
-        /// </summary>
-        public readonly double Opacity;
-
-        /// <summary>
-        /// Either undefined (solid line), dashed, or dotted. Default is undefined
-        /// </summary>
-        public readonly LineStyle? LineStyle;
-
-        public LineVisualStyle(
-            double width = 0.1,
-            Color? color = null,
-            double opacity = 0.5,
-            LineStyle? lineStyle = null
-        )
-        {
-            Width = width;
-            Color = color ?? Color.White;
-            Opacity = opacity;
-            LineStyle = lineStyle;
-        }
-    }
-
-    public readonly struct PolyVisualStyle
-    {
-        /// <summary>
-        /// Fill color. Default is #ffffff
-        /// </summary>
-        public readonly Color Fill;
-
-        /// <summary>
-        /// Opacity value, default is 0.5
-        /// </summary>
-        public readonly double Opacity;
-
-        /// <summary>
-        /// Stroke color. Default is #ffffff
-        /// </summary>
-        public readonly Color Stroke;
-
-        /// <summary>
-        /// Stroke line width, default is 0.1
-        /// </summary>
-        public readonly double StrokeWidth;
-
-        /// <summary>
-        /// Either undefined (solid line), dashed, or dotted. Default is undefined
-        /// </summary>
-        public readonly LineStyle? LineStyle;
-
-        public PolyVisualStyle(
-            Color? fill = null,
-            double opacity = 0.5,
-            Color? stroke = null,
-            double strokeWidth = 0.1,
-            LineStyle? lineStyle = null
-        )
-        {
-            Fill = fill ?? Color.White;
-            Opacity = opacity;
-            Stroke = stroke ?? Color.White;
-            StrokeWidth = strokeWidth;
-            LineStyle = lineStyle;
-        }
-    }
-
-    public readonly struct RectVisualStyle
-    {
-        /// <summary>
-        /// Fill color. Default is #ffffff
-        /// </summary>
-        public readonly Color Fill;
-
-        /// <summary>
-        /// Opacity value, default is 0.5
-        /// </summary>
-        public readonly double Opacity;
-
-        /// <summary>
-        /// Stroke color. Default is #ffffff
-        /// </summary>
-        public readonly Color Stroke;
-
-        /// <summary>
-        /// Stroke line width, default is 0.1
-        /// </summary>
-        public readonly double StrokeWidth;
-
-        /// <summary>
-        /// Either undefined (solid line), dashed, or dotted. Default is undefined
-        /// </summary>
-        public readonly LineStyle? LineStyle;
-
-        public RectVisualStyle(
-            Color? fill = null,
-            double opacity = 0.5,
-            Color? stroke = null,
-            double strokeWidth = 0.1,
-            LineStyle? lineStyle = null
-        )
-        {
-            Fill = fill ?? Color.White;
-            Opacity = opacity;
-            Stroke = stroke ?? Color.White;
-            StrokeWidth = strokeWidth;
-            LineStyle = lineStyle;
-        }
-    }
-
-    public readonly struct TextVisualStyle
-    {
-        /// <summary>
-        /// Text align, either center, left, or right. Default is center
-        /// </summary>
-        public readonly TextAlign Align;
-
-        /// <summary>
-        /// Background color. Default is undefined (no background).
-        /// When background is enabled, text vertical align is set to middle(default is baseline)
-        /// </summary>
-        public readonly Color? BackgroundColor;
-
-        /// <summary>
-        /// Background rectangle padding, default is 0.3
-        /// </summary>
-        public readonly double BackgroundPadding;
-
-        /// <summary>
-        /// Font color. Default is #ffffff
-        /// </summary>
-        public readonly Color Color;
-
-        /// <summary>
-        /// Either a number or a string in one of the following forms:
-        /// <list type="bullet">
-        /// <item>"0.7" (relative size in game coordinates)</item>
-        /// <item>"20px" (absolute size in pixels)</item>
-        /// <item>"0.7 serif"</item>
-        /// <item>"bold italic 1.5 Times New Roman"</item>
-        /// </list>
-        /// </summary>
-        public readonly string? Font;
-
-        /// <summary>
-        /// Opacity value, default is 1.0
-        /// </summary>
-        public readonly double Opacity;
-
-        /// <summary>
-        /// Stroke color. Default is undefined (no stroke)
-        /// </summary>
-        public readonly Color? Stroke;
-
-        /// <summary>
-        /// Stroke line width, default is 0.15
-        /// </summary>
-        public readonly double StrokeWidth;
-
-        public TextVisualStyle(
-            TextAlign align = TextAlign.Center,
-            Color? backgroundColor = null,
-            double backgroundPadding = 0.3,
-            Color? color = null,
-            string? font = null,
-            double opacity = 1.0,
-            Color? stroke = null,
-            double strokeWidth = 0.15
-        )
-        {
-            Align = align;
-            BackgroundColor = backgroundColor;
-            BackgroundPadding = backgroundPadding;
-            Color = color ?? Color.White;
-            Font = font;
-            Opacity = opacity;
-            Stroke = stroke;
-            StrokeWidth = strokeWidth;
-        }
-    }
-
+    /// <param name="Align">Text align, either center, left, or right, default is center</param>
+    /// <param name="BackgroundColor">Background color, default is null (no background). When background is enabled, text vertical align is set to middle (default is baseline)</param>
+    /// <param name="BackgroundPadding">Background rectangle padding, default is 0.3</param>
+    /// <param name="Color">Font color, default is white</param>
+    /// <param name="Font">
+    /// Either a number or a string in one of the following forms:
+    /// <list type="bullet">
+    /// <item>"0.7" (relative size in game coordinates)</item>
+    /// <item>"20px" (absolute size in pixels)</item>
+    /// <item>"0.7 serif"</item>
+    /// <item>"bold italic 1.5 Times New Roman"</item>
+    /// </list>
+    /// </param>
+    /// <param name="Opacity">Opacity value, default is 1.0</param>
+    /// <param name="Stroke">Stroke color, default is null (no stroke)</param>
+    /// <param name="StrokeWidth">Stroke line width, default is 0.15</param>
+    public readonly record struct TextVisualStyle
+    (
+        TextAlign? Align = null,
+        Color? BackgroundColor = null,
+        double? BackgroundPadding = null,
+        Color? Color = null,
+        string? Font = null,
+        double? Opacity = null,
+        Color? Stroke = null,
+        double? StrokeWidth = null
+    );
 }

--- a/ScreepsDotNet.API/API/World/IMapVisual.cs
+++ b/ScreepsDotNet.API/API/World/IMapVisual.cs
@@ -15,68 +15,31 @@ namespace ScreepsDotNet.API.World
         SmallCaps
     }
 
-    public readonly struct MapTextVisualStyle
-    {
-        /// <summary>
-        /// Font color. Default is white.
-        /// </summary>
-        public readonly Color? Color;
-        /// <summary>
-        /// The font family, default is sans-serif
-        /// </summary>
-        public readonly string? FontFamily;
-        /// <summary>
-        /// The font size in game coordinates, default is 10
-        /// </summary>
-        public readonly double? FontSize;
-        /// <summary>
-        /// The font style ('normal', 'italic' or 'oblique')
-        /// </summary>
-        public readonly MapTextFontStyle? FontStyle;
-        /// <summary>
-        /// The font variant ('normal' or 'small-caps')
-        /// </summary>
-        public readonly MapTextFontVariant? FontVariant;
-        /// <summary>
-        /// Stroke color. Default is undefined (no stroke).
-        /// </summary>
-        public readonly Color? Stroke;
-        /// <summary>
-        /// Stroke width, default is 0.15.
-        /// </summary>
-        public readonly double? StrokeWidth;
-        /// <summary>
-        /// Background color. Default is undefined (no background). When background is enabled, text vertical align is set to middle (default is baseline).
-        /// </summary>
-        public readonly Color? BackgroundColor;
-        /// <summary>
-        /// Background rectangle padding, default is 2.
-        /// </summary>
-        public readonly double? BackgroundPadding;
-        /// <summary>
-        /// Text align, either center, left, or right. Default is center.
-        /// </summary>
-        public readonly TextAlign? Align;
-        /// <summary>
-        /// Opacity value, default is 0.5.
-        /// </summary>
-        public readonly double? Opacity;
-
-        public MapTextVisualStyle(Color? color = null, string? fontFamily = null, double? fontSize = null, MapTextFontStyle? fontStyle = null, MapTextFontVariant? fontVariant = null, Color? stroke = null, double? strokeWidth = null, Color? backgroundColor = null, double? backgroundPadding = null, TextAlign? align = null, double? opacity = null)
-        {
-            Color = color;
-            FontFamily = fontFamily;
-            FontSize = fontSize;
-            FontStyle = fontStyle;
-            FontVariant = fontVariant;
-            Stroke = stroke;
-            StrokeWidth = strokeWidth;
-            BackgroundColor = backgroundColor;
-            BackgroundPadding = backgroundPadding;
-            Align = align;
-            Opacity = opacity;
-        }
-    }
+    /// <param name="Color">Font color, default is white</param>
+    /// <param name="FontFamily">Font family, default is sans-serif</param>
+    /// <param name="FontSize">Font size in game coordinates, default is 10</param>
+    /// <param name="FontStyle">Font style, default is normal</param>
+    /// <param name="FontVariant">Font variant, default is normal</param>
+    /// <param name="Stroke">Stroke color, default is null (no stroke)</param>
+    /// <param name="StrokeWidth">Stroke width, default is 0.15</param>
+    /// <param name="BackgroundColor">Background color, default is null (no background). When background is enabled, text vertical align is set to middle (default is baseline)</param>
+    /// <param name="BackgroundPadding">Background rectangle padding, default is 2</param>
+    /// <param name="Align">Text horizontal align, default is center</param>
+    /// <param name="Opacity">Opacity value, default is 0.5</param>
+    public readonly record struct MapTextVisualStyle
+    (
+        Color? Color = null,
+        string? FontFamily = null,
+        double? FontSize = null,
+        MapTextFontStyle? FontStyle = null,
+        MapTextFontVariant? FontVariant = null,
+        Color? Stroke = null,
+        double? StrokeWidth = null,
+        Color? BackgroundColor = null,
+        double? BackgroundPadding = null,
+        TextAlign? Align = null,
+        double? Opacity = null
+    );
 
     /// <summary>
     /// Room visuals provide a way to show various visual debug info in game rooms.

--- a/ScreepsDotNet.API/Native/Arena/NativeVisual.cs
+++ b/ScreepsDotNet.API/Native/Arena/NativeVisual.cs
@@ -50,7 +50,7 @@ namespace ScreepsDotNet.Native.Arena
         public IVisual Circle(FractionalPosition position, CircleVisualStyle? style = null)
         {
             using var positionJs = position.ToJS();
-            using var styleJs = style?.ToJS();
+            var styleJs = style?.ToJS();
             Native_Circle(ProxyObject, positionJs, styleJs);
             return this;
         }
@@ -65,14 +65,14 @@ namespace ScreepsDotNet.Native.Arena
         {
             using var pos1Js = pos1.ToJS();
             using var pos2Js = pos2.ToJS();
-            using var styleJs = style?.ToJS();
+            var styleJs = style?.ToJS();
             Native_Line(ProxyObject, pos1Js, pos2Js, styleJs);
             return this;
         }
 
         public IVisual Poly(IEnumerable<FractionalPosition> points, PolyVisualStyle? style = null)
         {
-            using var styleJs = style?.ToJS();
+            var styleJs = style?.ToJS();
             var pointsJs = points.Select(x => x.ToJS()).ToArray();
             try
             {
@@ -88,7 +88,7 @@ namespace ScreepsDotNet.Native.Arena
         public IVisual Rect(FractionalPosition pos, double w, double h, RectVisualStyle? style = null)
         {
             using var posJs = pos.ToJS();
-            using var styleJs = style?.ToJS();
+            var styleJs = style?.ToJS();
             Native_Rect(ProxyObject, posJs, w, h, styleJs);
             return this;
         }
@@ -99,7 +99,7 @@ namespace ScreepsDotNet.Native.Arena
         public IVisual Text(string text, FractionalPosition pos, TextVisualStyle? style = null)
         {
             using var posJs = pos.ToJS();
-            using var styleJs = style?.ToJS();
+            var styleJs = style?.ToJS();
             Native_Text(ProxyObject, text, posJs, styleJs);
             return this;
         }

--- a/ScreepsDotNet.API/Native/Visual.cs
+++ b/ScreepsDotNet.API/Native/Visual.cs
@@ -1,6 +1,7 @@
 ﻿using System;
-using ScreepsDotNet.Interop;
+using System.Collections.Generic;
 
+using ScreepsDotNet.Interop;
 using ScreepsDotNet.API;
 
 namespace ScreepsDotNet.Native
@@ -8,78 +9,155 @@ namespace ScreepsDotNet.Native
     [System.Runtime.Versioning.SupportedOSPlatform("wasi")]
     internal static class VisualExtensions
     {
-        public static string ToJS(this LineStyle lineStyle)
+        private static class Names
+        {
+            public static readonly Name Dotted = Name.Create("dotted");
+            public static readonly Name Dashed = Name.Create("dashed");
+            public static readonly Name Center = Name.Create("center");
+            public static readonly Name Left = Name.Create("left");
+            public static readonly Name Right = Name.Create("right");
+            public static readonly Name Radius = Name.Create("radius");
+            public static readonly Name Fill = Name.Create("fill");
+            public static readonly Name Opacity = Name.Create("opacity");
+            public static readonly Name Stroke = Name.Create("stroke");
+            public static readonly Name StrokeWidth = Name.Create("strokeWidth");
+            public static readonly Name LineStyle = Name.Create("lineStyle");
+            public static readonly Name Width = Name.Create("width");
+            public static readonly Name Color = Name.Create("color");
+            public static readonly Name Align = Name.Create("align");
+            public static readonly Name BackgroundColor = Name.Create("backgroundColor");
+            public static readonly Name BackgroundPadding = Name.Create("backgroundPadding");
+            public static readonly Name Font = Name.Create("font");
+        }
+
+        private static readonly Dictionary<CircleVisualStyle, JSObject> circleVisualStyleCache = [];
+        private static readonly Dictionary<LineVisualStyle, JSObject> lineVisualStyleCache = [];
+        private static readonly Dictionary<PolyVisualStyle, JSObject> polyVisualStyleCache = [];
+        private static readonly Dictionary<RectVisualStyle, JSObject> rectVisualStyleCache = [];
+        private static readonly Dictionary<TextVisualStyle, JSObject> textVisualStyleCache = [];
+
+        public static Name ToJS(this LineStyle lineStyle)
             => lineStyle switch
             {
-                LineStyle.Dotted => "dotted",
-                LineStyle.Dashed => "dashed",
+                LineStyle.Dotted => Names.Dotted,
+                LineStyle.Dashed => Names.Dashed,
                 _ => throw new ArgumentException($"Unknown line style", nameof(lineStyle)),
             };
 
-        public static string ToJS(this TextAlign textAlign)
+        public static Name ToJS(this TextAlign textAlign)
             => textAlign switch
             {
-                TextAlign.Center => "center",
-                TextAlign.Left => "left",
-                TextAlign.Right => "right",
+                TextAlign.Center => Names.Center,
+                TextAlign.Left => Names.Left,
+                TextAlign.Right => Names.Right,
                 _ => throw new ArgumentException($"Unknown text align", nameof(textAlign)),
             };
 
-        public static JSObject ToJS(this CircleVisualStyle circleVisualStyle)
+        public static JSObject ToJSRaw(this CircleVisualStyle circleVisualStyle)
         {
             var obj = JSObject.Create();
-            obj.SetProperty("radius", circleVisualStyle.Radius);
-            obj.SetProperty("fill", circleVisualStyle.Fill.ToString());
-            obj.SetProperty("opacity", circleVisualStyle.Opacity);
-            obj.SetProperty("stroke", circleVisualStyle.Stroke.ToString());
-            obj.SetProperty("strokeWidth", circleVisualStyle.StrokeWidth);
-            if (circleVisualStyle.LineStyle.HasValue) { obj.SetProperty("lineStyle", circleVisualStyle.LineStyle.Value.ToJS()); }
+            if (circleVisualStyle.Radius != null) { obj.SetProperty(Names.Radius, circleVisualStyle.Radius.Value); }
+            if (circleVisualStyle.Fill != null) { obj.SetProperty(Names.Fill, circleVisualStyle.Fill.Value.ToString()); }
+            if (circleVisualStyle.Opacity != null) { obj.SetProperty(Names.Opacity, circleVisualStyle.Opacity.Value); }
+            if (circleVisualStyle.Stroke != null) { obj.SetProperty(Names.Stroke, circleVisualStyle.Stroke.Value.ToString()); }
+            if (circleVisualStyle.StrokeWidth != null) { obj.SetProperty(Names.StrokeWidth, circleVisualStyle.StrokeWidth.Value); }
+            if (circleVisualStyle.LineStyle != null) { obj.SetProperty(Names.LineStyle, circleVisualStyle.LineStyle.Value.ToJS()); }
+            return obj;
+        }
+
+        public static JSObject ToJS(this CircleVisualStyle circleVisualStyle)
+        {
+            if (!circleVisualStyleCache.TryGetValue(circleVisualStyle, out var obj))
+            {
+                obj = circleVisualStyle.ToJSRaw();
+                circleVisualStyleCache.Add(circleVisualStyle, obj);
+            }
+            return obj;
+        }
+
+        public static JSObject ToJSRaw(this LineVisualStyle lineVisualStyle)
+        {
+            var obj = JSObject.Create();
+            if (lineVisualStyle.Width != null) { obj.SetProperty(Names.Width, lineVisualStyle.Width.Value); }
+            if (lineVisualStyle.Color != null) { obj.SetProperty(Names.Color, lineVisualStyle.Color.Value.ToString()); }
+            if (lineVisualStyle.Opacity != null) { obj.SetProperty(Names.Opacity, lineVisualStyle.Opacity.Value); }
+            if (lineVisualStyle.LineStyle != null) { obj.SetProperty(Names.LineStyle, lineVisualStyle.LineStyle.Value.ToJS()); }
             return obj;
         }
 
         public static JSObject ToJS(this LineVisualStyle lineVisualStyle)
         {
+            if (!lineVisualStyleCache.TryGetValue(lineVisualStyle, out var obj))
+            {
+                obj = lineVisualStyle.ToJSRaw();
+                lineVisualStyleCache.Add(lineVisualStyle, obj);
+            }
+            return obj;
+        }
+
+        public static JSObject ToJSRaw(this PolyVisualStyle polyVisualStyle)
+        {
             var obj = JSObject.Create();
-            obj.SetProperty("width", lineVisualStyle.Width);
-            obj.SetProperty("color", lineVisualStyle.Color.ToString());
-            obj.SetProperty("opacity", lineVisualStyle.Opacity);
-            if (lineVisualStyle.LineStyle.HasValue) { obj.SetProperty("lineStyle", lineVisualStyle.LineStyle.Value.ToJS()); }
+            if (polyVisualStyle.Fill != null) { obj.SetProperty(Names.Fill, polyVisualStyle.Fill.Value.ToString()); }
+            if (polyVisualStyle.Opacity != null) { obj.SetProperty(Names.Opacity, polyVisualStyle.Opacity.Value); }
+            if (polyVisualStyle.Stroke != null) { obj.SetProperty(Names.Stroke, polyVisualStyle.Stroke.Value.ToString()); }
+            if (polyVisualStyle.StrokeWidth != null) { obj.SetProperty(Names.StrokeWidth, polyVisualStyle.StrokeWidth.Value); }
+            if (polyVisualStyle.LineStyle != null) { obj.SetProperty(Names.LineStyle, polyVisualStyle.LineStyle.Value.ToJS()); }
             return obj;
         }
 
         public static JSObject ToJS(this PolyVisualStyle polyVisualStyle)
         {
+            if (!polyVisualStyleCache.TryGetValue(polyVisualStyle, out var obj))
+            {
+                obj = polyVisualStyle.ToJSRaw();
+                polyVisualStyleCache.Add(polyVisualStyle, obj);
+            }
+            return obj;
+        }
+
+        public static JSObject ToJSRaw(this RectVisualStyle rectVisualStyle)
+        {
             var obj = JSObject.Create();
-            obj.SetProperty("fill", polyVisualStyle.Fill.ToString());
-            obj.SetProperty("opacity", polyVisualStyle.Opacity);
-            obj.SetProperty("stroke", polyVisualStyle.Stroke.ToString());
-            obj.SetProperty("strokeWidth", polyVisualStyle.StrokeWidth);
-            if (polyVisualStyle.LineStyle.HasValue) { obj.SetProperty("lineStyle", polyVisualStyle.LineStyle.Value.ToJS()); }
+            if (rectVisualStyle.Fill != null) { obj.SetProperty(Names.Fill, rectVisualStyle.Fill.Value.ToString()); }
+            if (rectVisualStyle.Opacity != null) { obj.SetProperty(Names.Opacity, rectVisualStyle.Opacity.Value.ToString()); }
+            if (rectVisualStyle.Stroke != null) { obj.SetProperty(Names.Stroke, rectVisualStyle.Stroke.Value.ToString()); }
+            if (rectVisualStyle.StrokeWidth != null) { obj.SetProperty(Names.StrokeWidth, rectVisualStyle.StrokeWidth.Value); }
+            if (rectVisualStyle.LineStyle != null) { obj.SetProperty(Names.LineStyle, rectVisualStyle.LineStyle.Value.ToJS()); }
             return obj;
         }
 
         public static JSObject ToJS(this RectVisualStyle rectVisualStyle)
         {
+            if (!rectVisualStyleCache.TryGetValue(rectVisualStyle, out var obj))
+            {
+                obj = rectVisualStyle.ToJSRaw();
+                rectVisualStyleCache.Add(rectVisualStyle, obj);
+            }
+            return obj;
+        }
+
+        public static JSObject ToJSRaw(this TextVisualStyle textVisualStyle)
+        {
             var obj = JSObject.Create();
-            obj.SetProperty("fill", rectVisualStyle.Fill.ToString());
-            obj.SetProperty("opacity", rectVisualStyle.Opacity);
-            obj.SetProperty("stroke", rectVisualStyle.Stroke.ToString());
-            obj.SetProperty("strokeWidth", rectVisualStyle.StrokeWidth);
-            if (rectVisualStyle.LineStyle.HasValue) { obj.SetProperty("lineStyle", rectVisualStyle.LineStyle.Value.ToJS()); }
+            if (textVisualStyle.Align != null) { obj.SetProperty(Names.Align, textVisualStyle.Align.Value.ToJS()); }
+            if (textVisualStyle.BackgroundColor != null) { obj.SetProperty(Names.BackgroundColor, textVisualStyle.BackgroundColor.Value.ToString()); }
+            if (textVisualStyle.BackgroundPadding != null) { obj.SetProperty(Names.BackgroundPadding, textVisualStyle.BackgroundPadding.Value); }
+            if (textVisualStyle.Color != null) { obj.SetProperty(Names.Color, textVisualStyle.Stroke.ToString()); }
+            if (textVisualStyle.Font != null) { obj.SetProperty(Names.Font, textVisualStyle.Font); }
+            if (textVisualStyle.Opacity != null) { obj.SetProperty(Names.Opacity, textVisualStyle.Opacity.Value); }
+            if (textVisualStyle.Stroke != null) { obj.SetProperty(Names.Stroke, textVisualStyle.Stroke.Value.ToString()); }
+            if (textVisualStyle.StrokeWidth != null) { obj.SetProperty(Names.StrokeWidth, textVisualStyle.StrokeWidth.Value); }
             return obj;
         }
 
         public static JSObject ToJS(this TextVisualStyle textVisualStyle)
         {
-            var obj = JSObject.Create();
-            obj.SetProperty("align", textVisualStyle.Align.ToJS());
-            if (textVisualStyle.BackgroundColor.HasValue) { obj.SetProperty("backgroundColor", textVisualStyle.BackgroundColor.Value.ToString()); }
-            obj.SetProperty("backgroundPadding", textVisualStyle.BackgroundPadding);
-            obj.SetProperty("color", textVisualStyle.Stroke.ToString());
-            if (textVisualStyle.Font != null) { obj.SetProperty("font", textVisualStyle.Font); }
-            obj.SetProperty("opacity", textVisualStyle.Opacity);
-            if (textVisualStyle.Stroke.HasValue) { obj.SetProperty("stroke", textVisualStyle.Stroke.Value.ToString()); }
-            obj.SetProperty("strokeWidth", textVisualStyle.StrokeWidth);
+            if (!textVisualStyleCache.TryGetValue(textVisualStyle, out var obj))
+            {
+                obj = textVisualStyle.ToJSRaw();
+                textVisualStyleCache.Add(textVisualStyle, obj);
+            }
             return obj;
         }
     }

--- a/ScreepsDotNet.API/Native/World/NativeRoomVisual.cs
+++ b/ScreepsDotNet.API/Native/World/NativeRoomVisual.cs
@@ -62,7 +62,7 @@ namespace ScreepsDotNet.Native.World
         {
             using var pos1Js = pos1.ToJS();
             using var pos2Js = pos2.ToJS();
-            using var styleJs = style?.ToJS();
+            var styleJs = style?.ToJS();
             Native_Line(ProxyObject, pos1Js, pos2Js, styleJs);
             return this;
         }
@@ -70,7 +70,7 @@ namespace ScreepsDotNet.Native.World
         public IRoomVisual Circle(FractionalPosition position, CircleVisualStyle? style = null)
         {
             using var positionJs = position.ToJS();
-            using var styleJs = style?.ToJS();
+            var styleJs = style?.ToJS();
             Native_Circle(ProxyObject, positionJs, styleJs);
             return this;
         }
@@ -78,14 +78,14 @@ namespace ScreepsDotNet.Native.World
         public IRoomVisual Rect(FractionalPosition pos, double w, double h, RectVisualStyle? style = null)
         {
             using var posJs = pos.ToJS();
-            using var styleJs = style?.ToJS();
+            var styleJs = style?.ToJS();
             Native_Rect(ProxyObject, posJs, w, h, styleJs);
             return this;
         }
 
         public IRoomVisual Poly(IEnumerable<FractionalPosition> points, PolyVisualStyle? style = null)
         {
-            using var styleJs = style?.ToJS();
+            var styleJs = style?.ToJS();
             var pointsJs = points.Select(x => x.ToJS()).ToArray();
             try
             {
@@ -101,7 +101,7 @@ namespace ScreepsDotNet.Native.World
         public IRoomVisual Text(string text, FractionalPosition pos, TextVisualStyle? style = null)
         {
             using var posJs = pos.ToJS();
-            using var styleJs = style?.ToJS();
+            var styleJs = style?.ToJS();
             Native_Text(ProxyObject, text, posJs, styleJs);
             return this;
         }


### PR DESCRIPTION
- Changed all style structures to be records with nullable fields (instead of defaulted). This is closer to the JS api and addresses some issues where you couldn't express 'undefined' in some cases despite that being a valid and meaningful option. 
- Added caching of style JS object to reduce interop with larger visuals. This should reduce cpu use of visuals due to crossing the wasm barrier significantly.

This is unfortunately a breaking change.