### PR TITLE
fix: CreepUpgradeControllerResult NoBodypart incorrect value

### DIFF
--- a/ScreepsDotNet.API/API/World/ICreep.cs
+++ b/ScreepsDotNet.API/API/World/ICreep.cs
@@ -619,7 +619,7 @@ namespace ScreepsDotNet.API.World
         /// <summary>
         /// There are no WORK body parts in this creep’s body.
         /// </summary>
-        NoBodypart = -10
+        NoBodypart = -12
     }
 
     public enum CreepWithdrawResult


### PR DESCRIPTION
When I was debugging some of my code I noticed that the CreepUpgradeControllerResult in the official documentation the `ERR_NO_BODYPART` int value is `-12` not `-10`. I was able to confirm this by running this in the screeps world. 

Here is the documentation where I found the discrepency: https://docs.screeps.com/api/#Creep.upgradeController